### PR TITLE
Update mcmod.info

### DIFF
--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -15,7 +15,6 @@
             "pizeroLOL/huige233/LupusParsec(aka Uris Herialos) > Contributors",
         "logoFile": "",
         "screenshots": [],
-        "requiredMods": ["thaumcraft@[6.1.BETA26,)"],
         "dependencies": []
     }
 ]


### PR DESCRIPTION
That line was messing up things a little bit don't allowing the mod info appear in the mods menu. It wasn't properly introduced at first and is better don't have it in the file for now.